### PR TITLE
Remove extra check for host

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@
 var mysql = require('mysql');
 
 module.exports = function (config) {
-  if (!config || !config.host) {
+  if (!config) {
     throw new Error('Need to provide MySQL connection information.');
   }
 


### PR DESCRIPTION
I'm using MySQL with a ClearDB package on Heroku. The ClearDB credentials come as an URL. The MySQL package is able to handle this url directly e.g. this works: 
````
var connection = mysql.createConnection(process.env["CLEARDB_DATABASE_URL"]);
````
However, this package (erroneously) checks if the host property is set. This prevents me from connecting to MySQL with an URL.