### PR TITLE
Remove default auto increments from table schema

### DIFF
--- a/createTables.sql
+++ b/createTables.sql
@@ -5,7 +5,7 @@ CREATE TABLE `botkit_user` (
   `team_id` char(9) NOT NULL,
   `user` varchar(36) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4639 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 CREATE TABLE `botkit_team` (
@@ -16,10 +16,10 @@ CREATE TABLE `botkit_team` (
   `token` varchar(51) NOT NULL,
   `bot` varchar(500) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4639 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
 CREATE TABLE `botkit_channel` (
   `id` char(9) NOT NULL,
   `json` MEDIUMTEXT NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4639 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
The auto increments aren't needed, and while its not a big issue, I think its cleaner if the tables start at 1.
